### PR TITLE
enable beast in addition to json

### DIFF
--- a/wingbits/ultrafeeder-data.txt
+++ b/wingbits/ultrafeeder-data.txt
@@ -48,7 +48,7 @@ MLATHUB_DISABLE=true
 #    mlat,feed.theairtraffic.com,31090,39004
 
 #Wingbits
-READSB_EXTRA_ARGS=--net-connector wingbits,30006,json_out
+READSB_EXTRA_ARGS=--net-connector wingbits,30006,json_out --net-connector wingbits,30015,beast_reduce_out -net-beast-reduce-optimize-for-mlat --net-beast-reduce-interval=0.125
 
 
 # --------------------------------------------------


### PR DESCRIPTION
Hello!
We have started testing to use beast instead of json. For this to work in docker the following change is needed.

Please note that just because this change is done, it wont be used, we are still testing and decide what stations use it for now.

Feel free to reach out on Discord or ask any questions here!

/Micke of Wingbits team.